### PR TITLE
Fix CLI imports for test execution

### DIFF
--- a/passkit_cli/cli.py
+++ b/passkit_cli/cli.py
@@ -1,6 +1,4 @@
 import click
-from .membership import create_program, enrol_member
-from .coupons import create_coupon
 
 @click.group()
 def cli():
@@ -13,6 +11,7 @@ def membership():
 @membership.command('create-program')
 @click.option('--name', default='Quickstart Program', help='Program name')
 def membership_create_program(name):
+    from .membership.create_program import create_program
     program_id = create_program(name)
     click.echo(f'Created program: {program_id}')
 
@@ -23,6 +22,7 @@ def membership_create_program(name):
 @click.option('--surname', required=True)
 @click.option('--email', required=True)
 def membership_enrol_member(program_id, tier_id, forename, surname, email):
+    from .membership.enrol_member import enrol_member
     member_id = enrol_member(program_id, tier_id, forename, surname, email)
     click.echo(f'Enrolled member: {member_id}')
 
@@ -37,6 +37,7 @@ def coupons():
 @click.option('--surname', required=True)
 @click.option('--email', required=True)
 def coupons_create(campaign_id, offer_id, forename, surname, email):
+    from .coupons.create_coupon import create_coupon
     coupon_id = create_coupon(campaign_id, offer_id, forename, surname, email)
     click.echo(f'Created coupon: {coupon_id}')
 


### PR DESCRIPTION
## Summary
- avoid importing heavy modules at CLI load time
- move membership and coupon imports into command functions

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ad9c3cd04832a97249b59142183d9