### PR TITLE
Fix editable install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,7 @@ dependencies = [
 [project.scripts]
 passkit = "passkit_cli.cli:cli"
 
+[tool.setuptools.packages.find]
+include = ["passkit_cli*"]
+exclude = ["tests", "images"]
+


### PR DESCRIPTION
## Summary
- limit package discovery to `passkit_cli`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bc26502c4832aaa7bd3877394b8e8